### PR TITLE
add id's on homepage for direct linking

### DIFF
--- a/bcdevexchange/Views/Home/Index.cshtml
+++ b/bcdevexchange/Views/Home/Index.cshtml
@@ -137,7 +137,7 @@
     <!-- Learning teaser end -->
     
     <!-- Community section start -->
-    <div class="section_main bg-light text-dark">
+    <div class="section_main bg-light text-dark" id="community">
         <div class="section_inner">
             <div class="container">
                 <div class="row">
@@ -165,7 +165,7 @@
     <!-- Community section end -->
     
     <!-- Podcast Teaser section start -->
-    <div class="section_main bg-secondary">
+    <div class="section_main bg-secondary" id="podcasts">
         <div class="container">
             <div class="row d-flex flex-row-reverse">
                 <div class="col-md">


### PR DESCRIPTION
Heather wanted to be able to provide links from the Lab newsletter directly to the Podcast section of the homepage. Added an id for the Community section as well in case we want to use it later.